### PR TITLE
Base64 func

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,10 @@ The result of expanding the template will be output to stdout, where it can be r
 kexpand supports two different forms of variables: `$((key))` will output a non-quoted value (`$((replicas))` => `3`),
 while `$(key)` will output a quoted value (`$(replicas)` => `"3"`). A legacy format, `{{key}}`, is also supported, but
 not recommended for use.
+
+## Variable names
+Variables names can include any alphanumeric character along with hypens(-), period(.), and underscores(_).
+
+## Base64 support.
+Base64 encoding of values in supported by using the formats `$base64(key)`, `$base64((key))`, and `base64{{key}}`.  This
+is useful for secret definitions.

--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ not recommended for use.
 Variables names can include any alphanumeric character along with hypens(-), period(.), and underscores(_).
 
 ## Base64 support.
-Base64 encoding of values in supported by using the formats `$base64(key)`, `$base64((key))`, and `base64{{key}}`.  This
+Base64 encoding of values is supported by adding `|base64` to the key as in `$(key|base64)`, `$((key|base64))`, and `{{keyi|base64}}`.  This
 is useful for secret definitions.

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -72,7 +72,7 @@ func (c *ExpandCmd) Run(args []string) error {
 	expanded := src
 	{
 		// quoted form: $(key) => "value"
-		re := regexp.MustCompile(`(?i)\$\([a-z_\.]+\)`)
+		re := regexp.MustCompile(`\$\([[:alnum:]_\.]+\)`)
 		expandFunction := func(match []byte) []byte {
 			if match[0] != '$' || match[1] != '(' || match[len(match)-1] != ')' {
 				glog.Fatalf("unexpected match: %q", string(match))
@@ -96,7 +96,7 @@ func (c *ExpandCmd) Run(args []string) error {
 	{
 		// unquoted form: $((key)) => value
 
-		re := regexp.MustCompile(`(?i)\$\(\([a-z_\.]+\)\)`)
+		re := regexp.MustCompile(`\$\(\([[:alnum:]_\.]+\)\)`)
 		expandFunction := func(match []byte) []byte {
 			if match[0] != '$' || match[1] != '(' || match[2] != '(' || match[len(match)-1] != ')' || match[len(match)-2] != ')' {
 				glog.Fatalf("unexpected match: %q", string(match))
@@ -120,7 +120,7 @@ func (c *ExpandCmd) Run(args []string) error {
 	{
 		// legacy form: {{key}} => value
 
-		re := regexp.MustCompile(`\{\{[a-z_\.]+\}\}`)
+		re := regexp.MustCompile(`\{\{[[:alnum:]_\.]+\}\}`)
 		expandFunction := func(match []byte) []byte {
 			if match[0] != '{' || match[1] != '{' || match[len(match)-1] != '}' || match[len(match)-2] != '}' {
 				glog.Fatalf("unexpected match: %q", string(match))

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -72,7 +72,7 @@ func (c *ExpandCmd) Run(args []string) error {
 	expanded := src
 	{
 		// quoted form: $(key) => "value"
-		re := regexp.MustCompile(`\$\([[:alnum:]_\.]+\)`)
+		re := regexp.MustCompile(`\$\([[:alnum:]_\.\-]+\)`)
 		expandFunction := func(match []byte) []byte {
 			if match[0] != '$' || match[1] != '(' || match[len(match)-1] != ')' {
 				glog.Fatalf("unexpected match: %q", string(match))
@@ -96,7 +96,7 @@ func (c *ExpandCmd) Run(args []string) error {
 	{
 		// unquoted form: $((key)) => value
 
-		re := regexp.MustCompile(`\$\(\([[:alnum:]_\.]+\)\)`)
+		re := regexp.MustCompile(`\$\(\([[:alnum:]_\.\-]+\)\)`)
 		expandFunction := func(match []byte) []byte {
 			if match[0] != '$' || match[1] != '(' || match[2] != '(' || match[len(match)-1] != ')' || match[len(match)-2] != ')' {
 				glog.Fatalf("unexpected match: %q", string(match))
@@ -120,7 +120,7 @@ func (c *ExpandCmd) Run(args []string) error {
 	{
 		// legacy form: {{key}} => value
 
-		re := regexp.MustCompile(`\{\{[[:alnum:]_\.]+\}\}`)
+		re := regexp.MustCompile(`\{\{[[:alnum:]_\.\-]+\}\}`)
 		expandFunction := func(match []byte) []byte {
 			if match[0] != '{' || match[1] != '{' || match[len(match)-1] != '}' || match[len(match)-2] != '}' {
 				glog.Fatalf("unexpected match: %q", string(match))

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -74,7 +74,7 @@ func (c *ExpandCmd) Run(args []string) error {
 
 	{
 		// All
-		expr := `\$(base64)?(\({1,2})([a-zA-Z0-9_\.\-]+)\){1,2}|(base64)?(\{{2})([a-zA-Z0-9_\.\-]+)\}{2}`
+		expr := `\$(base64)?(\({1,2})([[:alnum:]_\.\-]+)\){1,2}|(base64)?(\{{2})([[:alnum:]_\.\-]+)\}{2}`
 		re := regexp.MustCompile(expr)
 		expandFunction := func(match []byte) []byte {
 			re := regexp.MustCompile(expr)


### PR DESCRIPTION
Feature: Adds the feature of prefixing `base64` before either the parenths`((` or braces`{{` to encode the returned value base base64. `$base(key)`, `$base64((key))`, and `base64{{key}}` are now supported.  See README.md for updated information.

Use case: when using template files for secrets, the value is expected to be sent to the api in base64 encoding.  This allows the variables file or `-k=key=value` flag to be plain text.

Other changes: This also reduces the repetition of the code from 3 functions for each format, to a single function.

Test run:

```
/tmp/base64 $ cat mysecret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: mysecret
data:
  quotedName: $(name)
  quotedBase64Name: $base64(name)
  s3Bucket: $((s3_bucket))
  base64S3Bucket: $base64((s3_bucket))
  legacyWebsite: {{Website}}
  base64LegacyWebsite: base64{{Website}}

/tmp/base64 $ cat values.yaml
name: Dennis
s3_bucket: my-bucket
Website: github.com

/tmp/base64 $ kexpand expand -f values.yaml mysecret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: mysecret
data:
  quotedName: "Dennis"
  quotedBase64Name: "RGVubmlz"
  s3Bucket: my-bucket
  base64S3Bucket: bXktYnVja2V0
  legacyWebsite: github.com
  base64LegacyWebsite: Z2l0aHViLmNvbQ==
```
