### PR TITLE
Support additional sources: terraform and a filetree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ gocode_docker:
 gofmt:
 	gofmt -w -s main.go
 	gofmt -w -s cmd
+	gofmt -w -s pkg
 
 build-in-docker:
 	docker run -it -v `pwd`:/src golang:1.7 /src/images/kexpand/onbuild.sh

--- a/pkg/source/filetree.go
+++ b/pkg/source/filetree.go
@@ -1,0 +1,48 @@
+package source
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+)
+
+type FiletreeSource struct {
+}
+
+func (t *FiletreeSource) Build(basedir string, prefix string) (map[string]interface{}, error) {
+	values := make(map[string]interface{})
+
+	err := t.addBlobs(values, basedir, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	return values, nil
+}
+
+func (t *FiletreeSource) addBlobs(dest map[string]interface{}, dir string, keyPrefix string) error {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("error listing directory %q: %v", dir, err)
+	}
+
+	for _, f := range files {
+		childKey := keyPrefix + f.Name()
+		if f.IsDir() {
+			err := t.addBlobs(dest, dir, childKey+".")
+			if err != nil {
+				return err
+			}
+		} else {
+			childPath := path.Join(dir, f.Name())
+			contents, err := ioutil.ReadFile(childPath)
+			if err != nil {
+				return fmt.Errorf("error reading file %q: %v", childPath, err)
+			}
+
+			dest[childKey] = contents
+		}
+	}
+
+	return nil
+}

--- a/pkg/source/terraform.go
+++ b/pkg/source/terraform.go
@@ -1,0 +1,85 @@
+package source
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type TerraformSource struct {
+}
+
+type tfState struct {
+	Version          int    `json:"version"`
+	TerraformVersion string `json:"terraform_version"`
+	Serial           int    `json:"serial"`
+	Lineage          string `json:"lineage"`
+
+	Modules []*tfStateModule `json:"modules"`
+}
+
+type tfStateModule struct {
+	Path      []string                    `json:"path"`
+	Resources map[string]*tfStateResource `json:"resources"`
+	Outputs   map[string]*tfStateOutput   `json:"outputs"`
+
+	DependsOn []string `json:"depends_on"`
+}
+
+type tfStateResource struct {
+	Type      string         `json:"type"`
+	DependsOn []string       `json:"depends_on"`
+	Primary   *tfStateObject `json:"primary"`
+	//"deposed": [],
+	//"provider": ""
+}
+
+type tfStateObject struct {
+	Id         string                 `json:"id"`
+	Attributes map[string]interface{} `json:"attributes"`
+}
+
+type tfStateOutput struct {
+	Sensitive bool        `json:"sensitive"`
+	Type      string      `json:"type"`
+	Value     interface{} `json:"value"`
+}
+
+func (t *TerraformSource) Parse(src []byte) (map[string]interface{}, error) {
+	tf := &tfState{}
+	err := json.Unmarshal(src, tf)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing tfstate file: %v", err)
+	}
+
+	values := make(map[string]interface{})
+
+	for _, module := range tf.Modules {
+		path := []string{"tf"}
+		for i, p := range module.Path {
+			if i == 0 && p == "root" {
+				continue
+			}
+			path = append(path, p)
+		}
+		prefix := strings.Join(path, ".")
+		if prefix != "" {
+			prefix += "."
+		}
+
+		for key, output := range module.Outputs {
+			values[prefix+key] = output.Value
+		}
+
+		for key, resource := range module.Resources {
+			if resource.Primary == nil {
+				continue
+			}
+			for k, v := range resource.Primary.Attributes {
+				values[prefix+key+"."+k] = v
+			}
+		}
+	}
+
+	return values, nil
+}


### PR DESCRIPTION
We import terraform variables & outputs; use --v=8 to see the values,
but the syntax is `tf.<tfname>`

We also import a directory tree of files, exposing them as binary
objects which are typically piped to the base64 function.