### PR TITLE
Adds multi-file and wildcard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ not recommended for use.
 ## Variable names
 Variables names can include any alphanumeric character along with hypens(-), period(.), and underscores(_).
 
+## Multiple files
+kexpand supprts passing multiple files and wildcards for templates to specify multiple files at once. kexpand will add `---` 
+between each filename as required by kubectl.
+
+`kexpand *.tmpl.yaml -f values.yaml`
+
 ## Base64 support.
 Base64 encoding of values is supported by adding `|base64` to the key as in `$(key|base64)`, `$((key|base64))`, and `{{keyi|base64}}`.  This
 is useful for secret definitions.


### PR DESCRIPTION
Adds multi-file support to resolve #30 

You can specify either a single file, multiple files, a wildcard pattern (`*.yaml`), or a combination.

Tests 
```==> f1.yaml <==
value1: $((value1))
value2: $((value2))

==> f2.yaml <==
value3: $((value3))
value4: $((value4))

==> f3.yaml <==
value5: $((value5))
value6: $((value6))

==> vals.var <==
value1: This
value2: is
value3: a
value4: multi
value5: file
value6: test

$ kexpand expand -f vals.var f1.yaml
value1: This
value2: is

$ kexpand expand -f vals.var f1.yaml f2.yaml f3.yaml
value1: This
value2: is

---
value3: a
value4: multi

---
value5: file
value6: test

$ kexpand expand -f vals.var *.yaml
value1: This
value2: is

---
value3: a
value4: multi

---
value5: file
value6: test```