### PR TITLE
adds kubectl to docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: gocode
 
 DOCKER_REGISTRY=kopeio
 UNIQUE:=$(shell date +%s)
-GOVERSION=1.7.4
+GOVERSION=1.8.1
 GITSHA := $(git describe --always)
 ifndef VERSION
   VERSION=0.2
@@ -41,7 +41,7 @@ gofmt:
 	gofmt -w -s pkg
 
 build-in-docker:
-	docker run -it -v `pwd`:/src golang:1.7 /src/images/kexpand/onbuild.sh
+	docker run -it -v `pwd`:/src golang:${GOVERSION} /src/images/kexpand/onbuild.sh
 
 image: build-in-docker
 	docker build -t ${DOCKER_REGISTRY}/kexpand  -f images/kexpand/Dockerfile .

--- a/images/kexpand/Dockerfile
+++ b/images/kexpand/Dockerfile
@@ -1,4 +1,18 @@
-FROM alpine:3.4
+FROM alpine:3.5
+
+# KUBECTL_SOURCE: Change to kubernetes-dev/ci for CI
+ARG KUBECTL_SOURCE=kubernetes-release/release
+
+# KUBECTL_TRACK: Currently latest from KUBECTL_SOURCE. Change to latest-1.3.txt, etc. if desired.
+ARG KUBECTL_TRACK=stable.txt
+
+RUN set -ex && \
+        apk add --no-cache --virtual deps curl jq ca-certificates && \
+        KUBECTL_VERSION=$(curl -SsL --retry 5 "https://storage.googleapis.com/${KUBECTL_SOURCE}/${KUBECTL_TRACK}") && \
+        curl -SsL --retry 5 "https://storage.googleapis.com/${KUBECTL_SOURCE}/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" > /usr/bin/kubectl && \
+        chmod +x /usr/bin/kubectl && \
+        apk del deps && \
+        rm -rf /var/cache/apk/*
 
 COPY /.build/artifacts/kexpand /kexpand
 


### PR DESCRIPTION
Resolves #31 
Also updates to alpine 3.5 base image and build-in-docker to use Go 1.8.1

The Dockerfile code for installing came from the kops [Dockerfile](https://github.com/kubernetes/kops/blob/master/docker/Dockerfile)