### PR TITLE
Support values defined via env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ spec:
     metadata:
       labels:
         app: $((name))
+        release: $((release))
     spec:
       containers:
       - name: $((name))
         image: tutum/hello-world
         ports:
-        - containerPort: 80
+        - containerPort: $((port))
 ```
 
 Into this:
@@ -49,6 +50,7 @@ spec:
     metadata:
       labels:
         app: hello-world
+        release: stable
     spec:
       containers:
       - name: hello-world
@@ -68,10 +70,13 @@ make
 
 ## Expanding variables
 
-The `expand` command will output the result of replacing all variables in the template file with the values from the
-provided values file:
+The `expand` command will output the result of replacing all variables in the template file with:
 
-`kexpand expand deployment.yaml -f values.yaml`
+* the values provided as command line parameters (-k)
+* values from the provided values file ('-f')
+* values defined in the environment ('-e')
+
+`release=stable kexpand expand deployment.yaml -f values.yaml -k port=80 -e`
 
 deployment.yaml:
 
@@ -86,12 +91,13 @@ spec:
     metadata:
       labels:
         app: $((name))
+        release: $((release))
     spec:
       containers:
       - name: $((name))
         image: tutum/hello-world
         ports:
-        - containerPort: 80
+        - containerPort: $((port))
 ```
 
 values.yaml:
@@ -103,7 +109,7 @@ replicas: 3
 
 The result of expanding the template will be output to stdout, where it can be redirected to a file or piped to `kubectl`:
 
-`kexpand expand deployment.yaml -f values.yaml | kubectl create -f -`
+`RELEASE=stable kexpand expand deployment.yaml -f values.yaml -k port=80 -e | kubectl create -f -`
 
 kexpand supports two different forms of variables: `$((key))` will output a non-quoted value (`$((replicas))` => `3`),
 while `$(key)` will output a quoted value (`$(replicas)` => `"3"`). A legacy format, `{{key}}`, is also supported, but


### PR DESCRIPTION
When no value found then with help of '-e' the environment can be looked
up for values.